### PR TITLE
Builder, exec, importer interfaces (WIP)

### DIFF
--- a/bake.go
+++ b/bake.go
@@ -1,0 +1,69 @@
+package bake
+
+import (
+	"net/url"
+	"path"
+)
+
+// Package represents a collection of targets.
+type Package struct {
+	Name    string
+	Targets []*Target
+}
+
+// Target returns a target by name or by output.
+func (p *Package) Target(name string) *Target {
+	for _, t := range p.Targets {
+		if t.Name == name {
+			return t
+		}
+
+		for _, output := range t.Outputs {
+			if output == name {
+				return t
+			}
+		}
+	}
+
+	return nil
+}
+
+// Target represents a rule or file within a package.
+type Target struct {
+	Name    string   // e.g. "test"
+	Command string   // command to execute
+	Inputs  []string // dependent input files
+	Outputs []string // declared outputs
+}
+
+type Label struct {
+	Package string
+	Target  string
+}
+
+// ParseLabel parses a URI string into a label.
+func ParseLabel(s string) (Label, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return Label{}, err
+	}
+
+	// Join host and path together to form package.
+	l := Label{}
+	if u.Host != "" && u.Path != "" {
+		l.Package = path.Join(u.Host, u.Path)
+	} else if u.Host != "" {
+		l.Package = u.Host
+	} else if u.Path != "" {
+		l.Package = u.Path
+	}
+
+	// Extract target from fragment. Otherwise use base of package.
+	if u.Fragment != "" {
+		l.Target = u.Fragment
+	} else {
+		l.Target = path.Base(l.Package)
+	}
+
+	return l, nil
+}

--- a/bake_test.go
+++ b/bake_test.go
@@ -1,0 +1,30 @@
+package bake_test
+
+import (
+	"testing"
+
+	"github.com/flynn/bake"
+)
+
+// Ensure targets can be retrieved by name.
+func TestPackage_Target(t *testing.T) {
+	pkg := &bake.Package{
+		Targets: []*bake.Target{
+			{Name: "foo"},
+			{Name: "bar"},
+			{Name: "baz"},
+		},
+	}
+	if target := pkg.Target("bar"); target == nil || target.Name != "bar" {
+		t.Fatalf("unexpected target: %#v", target)
+	}
+}
+
+// Ensure labels can be parsed into package and target names.
+func TestParseLabel(t *testing.T) {
+	if l, err := bake.ParseLabel("foo#test"); err != nil {
+		t.Fatal(err)
+	} else if l != (bake.Label{Package: "foo", Target: "test"}) {
+		t.Fatalf("unexpected label: %#v", l)
+	}
+}

--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,108 @@
+package bake
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrDependency is set on a build if a dependent build has an error.
+var ErrDependency = errors.New("dependency error")
+
+// Builder processes targets to produce an output Build.
+type Builder struct {
+	path    string          // working path
+	targets map[Label]Build // completed builds by label
+
+	// Imports packages by name.
+	// Package caching and remote retrieval are implemented in the importer.
+	Importer Importer
+
+	// Executes commands and returns output.
+	Execer Execer
+}
+
+// NewBuilder returns a new instance of Builder.
+func NewBuilder(path string) *Builder {
+	return &Builder{
+		path: path,
+	}
+}
+
+// Path returns the path that the builder was initialized with.
+func (b *Builder) Path() string { return b.path }
+
+// Build builds the target and outputs a build.
+func (b *Builder) Build(label string) *Build {
+	return b.buildTarget(label)
+}
+
+func (b *Builder) buildTarget(name string) (build *Build) {
+	build = &Build{}
+
+	// Parse label.
+	label, err := ParseLabel(name)
+	if err != nil {
+		build.Err = fmt.Errorf("parse label: %s", err)
+		return
+	}
+	build.Label = label
+
+	// Import the package if it hasn't been loaded yet.
+	pkg, err := b.Importer.Import(label.Package)
+	if err != nil {
+		build.Err = fmt.Errorf("import package: %s", err)
+		return
+	}
+
+	// Lookup target by name.
+	t := pkg.Target(label.Target)
+	if t == nil {
+		build.Err = fmt.Errorf("target not found: %s", label.Target)
+		return
+	}
+
+	// Build dependencies first.
+	for _, input := range t.Inputs {
+		subbuild := b.buildTarget(input)
+		build.Dependencies = append(build.Dependencies, subbuild)
+
+		// Exit if dependency errors out.
+		if subbuild.Err != nil {
+			build.Err = ErrDependency
+			return
+		}
+	}
+
+	// Build target.
+	cmd := b.Execer.Exec(t.Command)
+	// TODO: Attach stdout, stderr.
+	if err := cmd.Wait(); err != nil {
+		build.Err = err
+		return
+	}
+
+	// Copy outputs to build.
+	build.Outputs = make([]string, len(t.Outputs))
+	copy(build.Outputs, t.Outputs)
+
+	// TODO: Remove intermediate files.
+
+	return
+}
+
+// Build represents a build state for a target.
+type Build struct {
+	Label Label
+
+	// Root path of the build.
+	Path string
+
+	// Relative paths to files output by the build.
+	Outputs []string
+
+	// Set if an error occurred during the build process.
+	Err error
+
+	// Builds that this build depends on.
+	Dependencies []*Build
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,121 @@
+package bake_test
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/flynn/bake"
+)
+
+// Ensure the builder can build a target in a project with no dependencies.
+func TestBuilder_Build_NoDependencies(t *testing.T) {
+	// Create builder and mock exec call.
+	b := NewBuilder()
+	b.Importer.ImportFn = func(name string) (*bake.Package, error) {
+		if name != "myproj" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return &bake.Package{
+			Name: "myproj",
+			Targets: []*bake.Target{
+				{
+					Command: "go build -o bin/foo .",
+					Outputs: []string{"bin/foo"},
+				},
+			},
+		}, nil
+	}
+	b.Execer.ExecFn = func(cmd string) bake.Command {
+		if cmd != "go build -o bin/foo ." {
+			t.Fatalf("unexpected command: %s", cmd)
+		}
+		return &Command{stdout: "OK"}
+	}
+
+	// Build target and verify output.
+	build := b.Build("myproj#bin/foo")
+	if !reflect.DeepEqual(build, &bake.Build{
+		Label:   bake.Label{Package: "myproj", Target: "bin/foo"},
+		Outputs: []string{"bin/foo"},
+	}) {
+		t.Fatalf("unexpected build: %s", spew.Sdump(build))
+	}
+}
+
+// Ensure the builder can build a target in a project with with nested dependencies.
+func TestBuilder_Build_WithDependencies(t *testing.T) {
+	// Create builder and mock exec call.
+	b := NewBuilder()
+	b.Importer.ImportFn = func(name string) (*bake.Package, error) {
+		switch name {
+		case "A":
+			return &bake.Package{
+				Name: "A",
+				Targets: []*bake.Target{
+					{
+						Command: "make",
+						Inputs:  []string{"B#site.css"},
+						Outputs: []string{"main.exe"},
+					},
+				},
+			}, nil
+		case "B":
+			return &bake.Package{
+				Name: "B",
+				Targets: []*bake.Target{
+					{
+						Command: "lessc site.less site.css",
+						Outputs: []string{"site.css"},
+					},
+				},
+			}, nil
+		default:
+			t.Fatalf("unexpected import name: %q", name)
+			return nil, nil
+		}
+	}
+	b.Execer.ExecFn = func(cmd string) bake.Command { return &Command{} }
+
+	// Build target and verify output.
+	build := b.Build("A#main.exe")
+	if !reflect.DeepEqual(build, &bake.Build{
+		Label:   bake.Label{Package: "A", Target: "main.exe"},
+		Outputs: []string{"main.exe"},
+		Dependencies: []*bake.Build{
+			{
+				Label:   bake.Label{Package: "B", Target: "site.css"},
+				Outputs: []string{"site.css"},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected build: %s", spew.Sdump(build))
+	}
+}
+
+// Builder represents a mockable test wrapper for bake.Builder.
+type Builder struct {
+	*bake.Builder
+	Importer Importer
+	Execer   Execer
+}
+
+// NewBuilder returns a new instance of Builder.
+func NewBuilder() *Builder {
+	f, _ := ioutil.TempFile("", "bake-")
+	f.Close()
+	os.RemoveAll(f.Name())
+
+	b := &Builder{Builder: bake.NewBuilder(f.Name())}
+	b.Builder.Importer = &b.Importer
+	b.Builder.Execer = &b.Execer
+	return b
+}
+
+// Close stops the builder and removes the underlying data.
+func (b *Builder) Close() error {
+	os.RemoveAll(b.Path())
+	return nil
+}

--- a/cmd/bake/main.go
+++ b/cmd/bake/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	m := NewMain()
+	if err := m.Run(os.Args[1:]); err != nil {
+		fmt.Fprintln(m.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// Main represents the main program execution.
+type Main struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewMain returns a new instance of Main.
+func NewMain() *Main {
+	return &Main{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+// Run executes the program.
+func (m *Main) Run(args ...string) error {
+	panic("FIXME: parse flags")
+	panic("FIXME: delegate to action")
+}

--- a/cmd/bake/main_test.go
+++ b/cmd/bake/main_test.go
@@ -1,0 +1,1 @@
+package bake

--- a/event.go
+++ b/event.go
@@ -1,0 +1,85 @@
+package bake
+
+/*
+// Event represents an event that occurs on a target.
+type Event interface {
+	event()
+}
+
+func (*CreatePackageEvent) event() {}
+
+// CreatePackageEvent represents the creation of a package on a workspace.
+type CreatePackageEvent struct {
+	Package *Package
+}
+
+func (*ReadFileEvent) event() {}
+
+// ReadFileEvent represents a read of a file by a target.
+type ReadFileEvent struct {
+	Target Target
+	File   *File
+}
+
+// WriteFileEvent represents a write of a file by a target.
+type WriteFileEvent struct {
+	Target Target
+	File   *File
+}
+
+// EventHandler represents an object that can receive events.
+type EventHandler interface {
+	HandleEvent(Event)
+}
+
+// EventHandlerFunc is a adapter to allow functions to implement EventHandler.
+type EventHandlerFunc func(Event)
+
+// HandleEvent calls fn(e).
+func (fn EventHandlerFunc) HandleEvent(e Event) { fn(e) }
+
+// EventDispatcher represents an object that can register handlers and dispatch events.
+type EventDispatcher interface {
+	AddHandler(h EventHandler)
+	RemoveHandler(h EventHandler)
+}
+
+// dispatcher manages event handlers and dispatches events.
+type dispatcher struct {
+	handlers []EventHandler
+}
+
+// newDispatcher returns a new instance of dispatcher.
+func newDispatcher() *dispatcher {
+	return &dispatcher{}
+}
+
+// addHandler adds h to the set of event listeners.
+func (d *dispatcher) addHandler(h EventHandler) {
+	d.handlers = append(d.handlers, h)
+}
+
+// removeHandler deletes h from the set of event listeners.
+func (d *dispatcher) removeHandler(h EventHandler) {
+	for i, handler := range d.handlers {
+		if handler == h {
+			copy(d.handlers[i:], d.handlers[i+1:])
+			d.handlers[len(d.handlers)-1] = nil
+			d.handlers = d.handlers[:len(d.handlers)-1]
+		}
+	}
+}
+
+// dispatch sends e to all registered handlers.
+func (d *dispatcher) dispatch(e Event) {
+	for _, h := range d.handlers {
+		h.HandleEvent(e)
+	}
+}
+
+type handlerFuncEntry struct {
+	EventHandlerFunc
+}
+
+func (h handlerFuncEntry) HandleEvent(e Event) { h.EventHandlerFunc(e) }
+*/

--- a/exec.go
+++ b/exec.go
@@ -1,0 +1,27 @@
+package bake
+
+import (
+	"io"
+)
+
+// Execer represents an object that can execute commands.
+type Execer interface {
+	Exec(cmd string) Command
+}
+
+// Command represents command execution. It is returned by the Execer.
+// These can be local commands or can be executed remotely.
+type Command interface {
+	// Output streams from command.
+	Stdout() io.Reader
+	Stderr() io.Reader
+
+	// Returns once the command has finished executing.
+	// A nil error is returned if the command was successful.
+	Wait() error
+
+	// Files read from and written to.
+	// These are not available until after Wait() has returned.
+	Inputs() []string
+	Outputs() []string
+}

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,32 @@
+package bake_test
+
+import (
+	"io"
+	"strings"
+
+	"github.com/flynn/bake"
+)
+
+// Execer represents a mock of bake.Execer.
+type Execer struct {
+	ExecFn func(cmd string) bake.Command
+}
+
+func (e *Execer) Exec(cmd string) bake.Command { return e.ExecFn(cmd) }
+
+// Command represents a mock bake.Command.
+type Command struct {
+	stdout string
+	stderr string
+	err    error
+
+	inputs  []string
+	outputs []string
+}
+
+func (c *Command) Stdout() io.Reader { return strings.NewReader(c.stdout) }
+func (c *Command) Stderr() io.Reader { return strings.NewReader(c.stderr) }
+func (c *Command) Wait() error       { return c.err }
+
+func (c *Command) Inputs() []string  { return c.inputs }
+func (c *Command) Outputs() []string { return c.outputs }

--- a/importer.go
+++ b/importer.go
@@ -1,0 +1,6 @@
+package bake
+
+// Importer imports a package, possibly from a remote location.
+type Importer interface {
+	Import(name string) (*Package, error)
+}

--- a/importer_test.go
+++ b/importer_test.go
@@ -1,0 +1,12 @@
+package bake_test
+
+import (
+	"github.com/flynn/bake"
+)
+
+// Importer represents a mock of bake.Importer.
+type Importer struct {
+	ImportFn func(name string) (*bake.Package, error)
+}
+
+func (i *Importer) Import(name string) (*bake.Package, error) { return i.ImportFn(name) }


### PR DESCRIPTION
## Overview

This pull request sets up the main constructs in the `bake` build system. The current state consists primarily of the data types (`Project` & `Target`) as well as some basic flow for the `Builder`.
### Data Types

Bake's job is to build _projects_. A project is simply a collection of source files and targets. The targets are commands that take the source files and use them to generate derived files. This is similar to how a `Makefile` uses source files (`.c` & `.h` files) to generate binary files.

Targets can be specified as named targets (e.g. `test`) which is similar to `make`'s phony targets or they can be looked up by the files they generate (e.g. `myprog.exe`).
#### Labels

Targets are looked up by _labels_ which are a combination of the project name and the target. For example, an `apache2` project with the binary output file of `bin/httpd` would look like: 

```
apache2:bin/httpd
```

To specify a specific version, a hash can be appended:

```
apache2#v2.4.16:bin/httpd
```

Or the hash could be used for a git sha:

```
apache2#8e9da2e:bin/httpd
```

_Note: The code for label parsing currently use a URL encoding scheme of `project#target` but this needs to be changed to the format mentioned above._
### Building

The `Builder` is the workhorse of the build system. It has a single method for building a target:

```
Build(label string) *Build
```

The builder then goes through the following steps to execute a build:
1. Parse the label into package & target names.
2. Use the `Importer` to import the package by name.
3. Find the target in the package.
4. Iterate over each dependency of the target and recursively build.
5. Use the `Execer` to execute the command for the target.
6. Copy output files and logs from the command to the build.
7. Return the nested build object.

The resulting `Build` object contains all the necessary information for output files, build logs, & files read and written by the command. The implementation of `Command` is deferred to the `Execer` so a 9P execer an handle file events differently than a FUSE execer.
### Importing

The responsibility of retrieving projects belongs to the `Importer`. The implementation can be to retrieve a git repository or to download a tarball, etc. Because it is an interface, it can easily be wrapped with a caching layer or it could be overridden with a local directory lookup.

The `Importer` has one method:

```
Import(name string) (*Package, error)
```
### Exec

The execution of commands to convert source files into derived files is the job of the `Execer`. It has the responsibility of streaming out stdout and stderr logs as well has returning error from the process after it's finished. It also holds a list of specific files read and files written while the command was running. This information is used for two purposes:
1. Read files let us know what individual files this target depends on so that we can only rerun this target if those dependencies are changed.
2. Written files that are not listed in the target's declared list of output files are assumed to be temporary files and can be removed after the build is complete.
