### PR TITLE
Resolve symlinks when serving 9p

### DIFF
--- a/cmd/bake/main.go
+++ b/cmd/bake/main.go
@@ -114,6 +114,13 @@ func (m *Main) Run() error {
 	if err != nil {
 		return fmt.Errorf("abs path: %s", err)
 	}
+
+	// Ensure root is not a symbolic link.
+	// This causes issues with the 9p filesystem otherwise.
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("eval symlinks: %s", err)
+	}
 	m.Root = root
 
 	// Initialize snapshot.


### PR DESCRIPTION
## Overview

Using a symbolic link for a root directory caused 9p to return an `"Unknown error 526"` error. This commit evaluates symlinks before passing paths to the filesystem.
